### PR TITLE
refactor: pass icon to input as component

### DIFF
--- a/frontend/src/components/InputWithIcon.tsx
+++ b/frontend/src/components/InputWithIcon.tsx
@@ -1,16 +1,12 @@
-import Card from "@mui/material/Card";
-import Input from "@mui/material/Input";
-
-import LockResetIcon from "@mui/icons-material/LockReset";
-import MailOutlineIcon from "@mui/icons-material/MailOutline";
-import FaceIcon from "@mui/icons-material/Face";
+import { Card, Input } from "@mui/material";
+import { SvgIconComponent } from "@mui/icons-material";
 
 interface TextBoxProps {
+  Icon: SvgIconComponent;
   label: string;
-  icon: string;
 }
 
-export const InputWithIcon = ({ label, icon }: TextBoxProps) => {
+export const InputWithIcon = ({ Icon, label }: TextBoxProps) => {
   return (
     <Card
       sx={{
@@ -21,30 +17,12 @@ export const InputWithIcon = ({ label, icon }: TextBoxProps) => {
         height: "40px",
       }}
     >
-      {icon === "Email" && (
-        <MailOutlineIcon
-          sx={{
-            color: "primary.main",
-            alignSelf: "center",
-          }}
-        />
-      )}
-      {icon === "Username" && (
-        <FaceIcon
-          sx={{
-            color: "primary.main",
-            alignSelf: "center",
-          }}
-        />
-      )}
-      {icon === "Password" && (
-        <LockResetIcon
-          sx={{
-            color: "primary.main",
-            alignSelf: "center",
-          }}
-        />
-      )}
+      <Icon
+        sx={{
+          color: "primary.main",
+          alignSelf: "center",
+        }}
+      />
       <Input
         sx={{
           marginLeft: "10px",

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,17 +1,13 @@
 import { useState } from "react";
 
-import Container from "@mui/material/Container";
-import Grid from "@mui/material/Grid";
-import Stack from "@mui/material/Stack";
-import Tab from "@mui/material/Tab";
-import TabContext from "@mui/lab/TabContext";
-import TabList from "@mui/lab/TabList";
-import TabPanel from "@mui/lab/TabPanel";
+import { Container, Grid, Stack, Tab } from "@mui/material";
 
 import { InputWithIcon } from "../components/InputWithIcon";
 
 import LogoImage from "../assets/images/Logo/Logo.png";
 import PairProgrammingImage from "../assets/images/PairProgramming/PairProgramming.png";
+import { Face, LockReset, MailOutline } from "@mui/icons-material";
+import { TabContext, TabList, TabPanel } from "@mui/lab";
 
 export const Login = () => {
   const [formType, setFormType] = useState<"login" | "signup">("login");
@@ -57,15 +53,15 @@ export const Login = () => {
             </TabList>
             <TabPanel value="login">
               <Stack spacing={4} alignItems="center">
-                <InputWithIcon label="Email" icon="Email" />
-                <InputWithIcon label="Password" icon="Password" />
+                <InputWithIcon label="Email" Icon={MailOutline} />
+                <InputWithIcon label="Password" Icon={LockReset} />
               </Stack>
             </TabPanel>
             <TabPanel value="signup">
               <Stack spacing={4} alignItems="center">
-                <InputWithIcon label="Email" icon="Email" />
-                <InputWithIcon label="Username" icon="Username" />
-                <InputWithIcon label="Password" icon="Password" />
+                <InputWithIcon label="Email" Icon={MailOutline} />
+                <InputWithIcon label="Username" Icon={Face} />
+                <InputWithIcon label="Password" Icon={LockReset} />
               </Stack>
             </TabPanel>
           </TabContext>


### PR DESCRIPTION
Refactor `InputWithIcon` to take in `Icon` as a component type rather than a string to improve extensibility.